### PR TITLE
Fixes install doppler on mac os

### DIFF
--- a/.circleci/deploy-orb.yml
+++ b/.circleci/deploy-orb.yml
@@ -26,11 +26,29 @@ jobs:
               echo "DOPPLER_TEST_SECRET is not set"
               exit 1
             fi
+  command-tests-on-mac:
+    macos:
+      xcode: "13.4.0"
+    steps:
+      - checkout
+      # Run your orb's commands to validate them.
+      - doppler/install
+      - doppler/load_secrets:
+          doppler_token: DOPPLER_TOKEN_TEST
+      - run:
+          name: check if env variables are set
+          command: |
+            if [ -z "$DOPPLER_TEST_SECRET" ]; then
+              echo "DOPPLER_TEST_SECRET is not set"
+              exit 1
+            fi
 workflows:
   deploy-orb:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       - command-tests:
+          filters: *filters
+      - command-tests-on-mac:
           filters: *filters
       - orb-tools/pack:
           filters: *filters
@@ -41,6 +59,7 @@ workflows:
           requires:
             - orb-tools/pack
             - command-tests
+            - command-tests-on-mac
           context: orb-publishing
           filters:
             branches:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,5 +1,5 @@
 description: >
-  Installs latest version of doppler.
+  Installs latest version of doppler. Supports linux(apt-get) and macos(brew) build agents.
 steps:
   - run:
       name: Install doppler

--- a/src/scripts/install_doppler.sh
+++ b/src/scripts/install_doppler.sh
@@ -18,7 +18,7 @@ then
     sudo apt-get install -y gnupg
   elif command -v brew &> /dev/null
   then
-    brew install gnupg
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install gnupg
   else
     echo "Please install gnupg before installing doppler. Unable to detect apt-get or homebrew"
     exit 1

--- a/src/scripts/install_doppler.sh
+++ b/src/scripts/install_doppler.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 set +e
 
-apt-get install -y sudo
-ls -al /bin/sh && sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh && ls -al /bin/sh
+# check if apt-get is present
+if command -v apt-get &> /dev/null
+then
+  # install sudo
+  apt-get install -y sudo
+  ls -al /bin/sh && sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh && ls -al /bin/sh
+fi
 
 (curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/install.sh || wget -t 3 -qO- https://cli.doppler.com/install.sh) | sudo sh
 doppler --version

--- a/src/scripts/install_doppler.sh
+++ b/src/scripts/install_doppler.sh
@@ -9,5 +9,21 @@ then
   ls -al /bin/sh && sudo rm /bin/sh && sudo ln -s /bin/bash /bin/sh && ls -al /bin/sh
 fi
 
+# Install gnupg if its not present
+if ! command -v gpg &> /dev/null
+then
+  # install gnupg
+  if command -v apt-get &> /dev/null
+  then
+    sudo apt-get install -y gnupg
+  elif command -v brew &> /dev/null
+  then
+    brew install gnupg
+  else
+    echo "Please install gnupg before installing doppler. Unable to detect apt-get or homebrew"
+    exit 1
+  fi
+fi
+
 (curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/install.sh || wget -t 3 -qO- https://cli.doppler.com/install.sh) | sudo sh
 doppler --version


### PR DESCRIPTION
It broke due to addition of `apt-get` which is not used on mac os. 